### PR TITLE
bugfixes (#16), code cleanup

### DIFF
--- a/src/tor_relay_scanner/scanner.py
+++ b/src/tor_relay_scanner/scanner.py
@@ -124,7 +124,7 @@ def start_browser():
 
 
 def str_list_with_prefix(prefix, list_):
-    return "\n".join([prefix + r for r in list_])
+    return "\n".join(prefix + r for r in list_)
 
 
 async def main_async(args):

--- a/src/tor_relay_scanner/scanner.py
+++ b/src/tor_relay_scanner/scanner.py
@@ -168,7 +168,7 @@ async def main_async(args):
                     relays_new.append(relay_copy)
         relays = relays_new
         if not relays:
-            print("There are no relays within specified port number constrains!", file=sys.stderr)
+            print("There are no relays within specified port number constraints!", file=sys.stderr)
             print("Try changing port numbers.", file=sys.stderr)
             return 2
 

--- a/src/tor_relay_scanner/scanner.py
+++ b/src/tor_relay_scanner/scanner.py
@@ -178,7 +178,7 @@ async def main_async(args):
             return 2
 
     working_relays = list()
-    numtries = round(len(relays) / NUM_RELAYS)
+    numtries = (len(relays) + NUM_RELAYS - 1) // NUM_RELAYS
     for ntry, chunk in enumerate(chunked_list(relays, NUM_RELAYS)):
         if len(working_relays) >= WORKING_RELAY_NUM_GOAL:
             break

--- a/src/tor_relay_scanner/scanner.py
+++ b/src/tor_relay_scanner/scanner.py
@@ -127,6 +127,11 @@ def str_list_with_prefix(prefix, list_):
     return "\n".join(prefix + r for r in list_)
 
 
+def chunked_list(l, size):
+    for i in range(0, len(l), size):
+        yield l[i:i+size]
+
+
 async def main_async(args):
     NUM_RELAYS = args.num_relays
     WORKING_RELAY_NUM_GOAL = args.working_relay_num_goal
@@ -173,29 +178,22 @@ async def main_async(args):
             return 2
 
     working_relays = list()
-    ntry = 0
-    relaypos = 0
     numtries = round(len(relays) / NUM_RELAYS)
-    for ntry in range(numtries):
+    for ntry, chunk in enumerate(chunked_list(relays, NUM_RELAYS)):
         if len(working_relays) >= WORKING_RELAY_NUM_GOAL:
             break
 
-        relaynum = min(NUM_RELAYS, len(relays) - relaypos - 1)
-        test_relays = [TorRelay(relays[x])
-                       for x in range(relaypos, relaypos+relaynum)]
-        relaypos += NUM_RELAYS
-
-        if not test_relays:
-            break
+        relaynum = len(chunk)
+        test_relays = [TorRelay(r) for r in chunk]
 
         print(
-            f"\nTry {ntry}/{numtries}, We'll test the following {NUM_RELAYS} random relays:", file=sys.stderr)
+            f"\nTry {ntry+1}/{numtries}, We'll test the following {relaynum} random relays:", file=sys.stderr)
         for relay in test_relays:
             print(relay, file=sys.stderr)
         print("", file=sys.stderr)
 
         if ntry:
-            print(f"Found {len(working_relays)} good relays so far. Test {ntry}/{numtries} started…", file=sys.stderr)
+            print(f"Found {len(working_relays)} good relays so far. Test {ntry+1}/{numtries} started…", file=sys.stderr)
         else:
             print(f"Test started…", file=sys.stderr)
 

--- a/src/tor_relay_scanner/scanner.py
+++ b/src/tor_relay_scanner/scanner.py
@@ -190,7 +190,7 @@ async def main_async(args):
             f"\nTry {ntry+1}/{numtries}, We'll test the following {relaynum} random relays:", file=sys.stderr)
         for relay in test_relays:
             print(relay, file=sys.stderr)
-        print("", file=sys.stderr)
+        print(file=sys.stderr)
 
         if ntry:
             print(f"Found {len(working_relays)} good relays so far. Test {ntry+1}/{numtries} started…", file=sys.stderr)
@@ -201,7 +201,7 @@ async def main_async(args):
         for relay in test_relays:
             tasks.append(asyncio.create_task(relay.check(TIMEOUT)))
         fin = await asyncio.gather(*tasks)
-        print("", file=sys.stderr)
+        print(file=sys.stderr)
 
         print("The following relays are reachable this try:", file=sys.stderr)
         for relay in test_relays:
@@ -214,7 +214,7 @@ async def main_async(args):
             print("No relays are reachable this try.", file=sys.stderr)
 
     if ntry > 1:
-        print("", file=sys.stderr)
+        print(file=sys.stderr)
         print("All reachable relays:", file=sys.stderr)
         for relay in working_relays:
             if relay:


### PR DESCRIPTION
This update gets rid of `relaypos` altogether and calculates `numtries` using a reliable ceiling division method,
thus eliminating the two bugs outlined in detail in https://github.com/ValdikSS/tor-relay-scanner/issues/16.
The rest is just code cleanup.